### PR TITLE
Drop lamnias-dependency-plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,7 @@
         "doctrine/doctrine-module": "^2.1 || ^4.0 || ^5.0",
         "laminas/laminas-modulemanager": "^2.7.2 || ^3.0.0",
         "laminas/laminas-eventmanager": "^3.0",
-        "laminas/laminas-servicemanager": "^3.1",
-        "laminas/laminas-dependency-plugin": "^2.0"
+        "laminas/laminas-servicemanager": "^3.1"
     },
     "require-dev": {
         "api-skeletons/coding-standard": "^1.0.0",


### PR DESCRIPTION
Drop laminas-dependency-plugin as it is not usefull anymore and not compatible with composer >=2.3 therefore preventing an install with PHP 8.2 constraint.